### PR TITLE
Fix pause/blib at end of GIFs

### DIFF
--- a/src/App/Camera/index.js
+++ b/src/App/Camera/index.js
@@ -88,7 +88,7 @@ class Camera extends Component {
   }
 
   capture = () => {
-    setTimeout(this.stopVideo, GIF_DURATION);
+    setTimeout(this.stopVideo, GIF_DURATION + 500);
     this.setState({ mode: SHOOTING }, () => {
       gifshot.createGIF({
         ...GIF_OPTIONS,


### PR DESCRIPTION
Fixes issue introduced by 4bf78263002726b8e4a7a6eca1b2b784bca7d342

The camera getting turned off was happening a little too soon, and affecting the GIF.