### PR TITLE
Set Lerna to version packages independently

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "independent"
 }


### PR DESCRIPTION
We don't want all of these packages to share a version number.