### PR TITLE
Intro: fix line-height

### DIFF
--- a/packages/thicket-intro/src/App/App.css
+++ b/packages/thicket-intro/src/App/App.css
@@ -5,7 +5,7 @@ body {
     Arial,sans-serif;
   font-weight: 300;
   font-size: calc(.85em + 1vw);
-  line-height: 1.5em;
+  line-height: 1.5;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
Removing the `em` makes it work much better.

Nothing looks obviously bad until viewed on a narrow screen, when the lines break and the leading of the headings looks wrong.