### PR TITLE
Intro: show GIF sending to Earth

### DIFF
--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
@@ -1,0 +1,85 @@
+.GifToEarthProgress {
+  position: sticky;
+  top: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 3em 0;
+}
+
+.GifToEarthProgress .mars {
+  height: 1.358em; /* Mars' diameter is 6790km, this is 2x that */
+}
+
+.GifToEarthProgress .earth {
+  height: 2.55em; /* Earth's diameter is 12750km, this is 2x that */
+}
+
+.GifToEarthProgress--progressBars {
+  flex: 1;
+  position: relative;
+}
+
+.GifToEarthProgress--progressBars progress {
+  /* Reset the default appearance */
+  appearance: none;
+
+  height: 0.2em;
+  width: 100%;
+  vertical-align: middle;
+}
+.GifToEarthProgress--progressBars progress.fromEarth {
+  transform: rotateY(180deg);
+}
+.GifToEarthProgress--progressBars progress::-webkit-progress-bar {
+  background-color: rgba(255,255,255,0.1);
+  border-radius: 2px;
+}
+.GifToEarthProgress--progressBars progress::-webkit-progress-value {
+  border-radius: 2px;
+}
+.GifToEarthProgress--progressBars progress.fromMars::-webkit-progress-value {
+  background-color: #e75252;
+}
+.GifToEarthProgress--progressBars progress.fromEarth::-webkit-progress-value {
+  background-color: #00A9E0;
+}
+
+.GifToEarthProgress .gif {
+  line-height: 0;
+  position: absolute;
+  width: 44px;
+}
+.GifToEarthProgress .gif.martian {
+  background-color: #e75252;
+  margin-left: -22px;
+  top: 100%;
+}
+.GifToEarthProgress .gif.terran {
+  background-color: #00A9E0;
+  bottom: 100%;
+  height: 34px;
+  line-height: 34px;
+  margin-right: -22px;
+}
+.GifToEarthProgress .gif img {
+  width: 40px;
+  margin: 2px;
+}
+.GifToEarthProgress .gif:after {
+  position: absolute;
+  left: 0;
+  border-left: 22px solid transparent;
+  border-right: 22px solid transparent;
+  content: " ";
+  font-size: 0;
+  line-height: 0;
+}
+.GifToEarthProgress .gif.martian:after {
+  bottom: 100%;
+  border-bottom: 11px solid #e75252;
+}
+.GifToEarthProgress .gif.terran:after {
+  top: 100%;
+  border-top: 11px solid #00A9E0;
+}

--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/index.js
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/index.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import mars from '../../WifiOffExplanation/mars.svg'
+import earth from '../../../Hero/earth.svg'
+import './GifToEarthProgress.css'
+
+const MILLISECONDS_TO_MARS = 3 * 60 * 1000
+
+const getProgress = start => {
+  const now = new Date()
+  return Math.min((now - start) / MILLISECONDS_TO_MARS, 1)
+}
+
+export default class GifToEarthProgress extends React.Component {
+  state = { progress: null }
+
+  componentDidMount() {
+    const { gifCreated } = this.props
+    const gifArrivesAtEarth = new Date(gifCreated.getTime() + 3000 * 60)
+    const now = new Date()
+
+    this.setState({ progress: getProgress(gifCreated) })
+
+    if (gifArrivesAtEarth > now) {
+      const interval = window.setInterval(
+        () => {
+          const progress = getProgress(gifCreated)
+          this.setState({ progress })
+          if (progress === 1) window.clearInterval(interval)
+        },
+        200
+      )
+    }
+  }
+
+  render() {
+    const { gif } = this.props
+    const { progress } = this.state
+
+    return (
+      <div className="GifToEarthProgress">
+        <img src={mars} alt="mars" className="mars" />
+        <div className="GifToEarthProgress--progressBars">
+          <div className="gif martian" style={{ left: `${progress * 100}%` }}>
+            <img src={gif} alt="your GIF" />
+          </div>
+          <div className="gif terran" style={{ right: `${progress * 100}%` }}>
+            ?
+          </div>
+          <progress value={progress} className="fromEarth" />
+          <progress value={progress} className="fromMars" />
+        </div>
+        <img src={earth} alt="earth" className="earth"  />
+      </div>
+    )
+  }
+}

--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/index.js
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/index.js
@@ -1,12 +1,16 @@
 import React from 'react'
+import GifToEarthProgress from './GifToEarthProgress'
 
-import Image from '../Image'
-
-export default ({ gif }) => [
-  <Image key="img" src={gif} alt="" />,
-  <h2 key="h2">Nice GIF!</h2>,
+export default ({ gif, gifCreated }) => [
+  <GifToEarthProgress key="img" gif={gif} gifCreated={gifCreated} />,
+  <h2 key="h2">Nice GIF! It's on its way back to Earth now.</h2>,
   <p key="p">
-    Once you go back online, your GIF can start its three minute journey back
-    to your friends on Earth!
+    Because of how Thicket works, we here on Mars <strong>can already see your
+    GIF</strong>. No round-trip to an Earth-bound server necessary! Your
+    friends on Earth will get it as fast as the pesky speed of light allows.
+  </p>,
+  <p key="p2">
+    And hey! It looks like they just sent you something, too! Stick around to
+    find out what it is.
   </p>,
 ]

--- a/packages/thicket-intro/src/App/GifCreator/index.js
+++ b/packages/thicket-intro/src/App/GifCreator/index.js
@@ -9,11 +9,15 @@ import './GifCreator.css'
 
 export default class GifCreator extends React.Component {
 
-  state = {
-    online: true,
-    creating: false,
-    gif: null,
-  }
+  state = (() => {
+    const gifCreated = window.localStorage.getItem('gifCreated')
+    return {
+      online: true,
+      creating: false,
+      gif: window.localStorage.getItem('gif'),
+      gifCreated: gifCreated && new Date(Number(gifCreated)),
+    }
+  })()
 
   componentDidMount() {
     window.addEventListener('online', this.goOnline, false)
@@ -30,19 +34,26 @@ export default class GifCreator extends React.Component {
 
   startCreating = () => this.setState({creating: true})
 
+  setGif = gif => {
+    window.localStorage.setItem('gif', gif)
+    const gifCreated = new Date()
+    window.localStorage.setItem('gifCreated', gifCreated.getTime())
+    this.setState({ gif, gifCreated, creating: false })
+  }
+
   render() {
     const { id } = this.props
-    const { gif, online, creating } = this.state
+    const { gif, gifCreated, online, creating } = this.state
 
     return (
       <div className="GifCreator" id={id}>
         <div className="GifCreator--Explanation">
           {gif
-            ? <NiceGif gif={gif} />
+            ? <NiceGif gif={gif} gifCreated={gifCreated} />
             : online
               ? <TurnOffWifi />
               : creating
-                ? <Camera onSave={gif => this.setState({ gif, creating: false })}/>
+                ? <Camera onSave={this.setGif}/>
                 : <WifiOffExplanation onActivate={this.startCreating} />
         }
         </div>


### PR DESCRIPTION
This looks great, but has some limitations currently:

* [ ] There's no **end state** - it promises that you will see a GIF in three minutes, if you stick around, but that does not happen
* [ ] There's no way to reset it - your GIF is saved in localStorage, but there's no way to reset the whole thing and start again
* [x] If there were more content on the page, the loader would scroll out of view when its section does. We need to move it to a parent section, which wraps all sections for which we want to keep this loader visible. _[Fixed by #63]_
* [x] It's not obvious that the user should start scrolling again. I will add the arrow from the first panel to the bottom of this one. _[Fixed by #64]_

I also feel like I might be trying to say too much, while still failing to communicate what makes Thicket special. I wish I didn't need a second paragraph. @s-small let me know if you can think of a way to improve this.

<image src="https://user-images.githubusercontent.com/221614/32077970-31a71d02-ba73-11e7-91b0-7344a2dd392c.png" alt="gif sending to earth" width="320px">
