### PR TITLE
Intro: set Hero min-height to 100vh, not height

### DIFF
--- a/packages/thicket-intro/src/App/Hero/Hero.css
+++ b/packages/thicket-intro/src/App/Hero/Hero.css
@@ -1,5 +1,5 @@
 .Hero {
-  height: 100vh;
+  min-height: 100vh;
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
If it's taller than the viewport, that's ok. We just don't want it to be shorter than.