### PR TITLE
Intro: affix header when needed

### DIFF
--- a/packages/thicket-intro/src/App/GifCreator/GifCreator.css
+++ b/packages/thicket-intro/src/App/GifCreator/GifCreator.css
@@ -10,4 +10,5 @@
   margin: 0 auto;
   padding: 1em;
   max-width: 30em;
+  position: relative;
 }

--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
@@ -6,20 +6,33 @@
 .GifToEarthProgress {
   background: #172B42;
   background: linear-gradient(to bottom, #172B42 0%, #172B42 95%, rgba(22,43,66,0) 100%);
-  position: sticky;
-  top: -2px;
+  top: 0;
+  left: 0;
+  width: 100%;
+  position: absolute;
+}
+.GifToEarthProgress > div {
+  margin: 0 auto;
+  padding: 32px 0;
+  width: calc(100% - 2em);
+  max-width: 30em;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 32px 0;
+}
+.GifToEarthProgress.sticky {
+  position: fixed;
+}
+.GifToEarthProgress + * {
+  margin-top: 115px; /* 2 x 32px padding + 51px height of earth */
 }
 
 .GifToEarthProgress .mars {
-  height: 1.358em; /* Mars' diameter is 6790km, this is 2x that */
+  height: 27.16px; /* Mars' diameter is 6790km, this is 4x that */
 }
 
 .GifToEarthProgress .earth {
-  height: 2.55em; /* Earth's diameter is 12750km, this is 2x that */
+  height: 51px; /* Earth's diameter is 12750km, this is 4x that */
 }
 
 .GifToEarthProgress--progressBars {


### PR DESCRIPTION
This uses `requestAnimationFrame` [as encouraged by MDN][1] to avoid [scroll jank][2]. It results in better UX than the `position: sticky` approach I attempted in #60.

It required quite a few changes to the styling of the box around the loader. I had to make it look like it was part of the page flow before making it `position: fixed`, but it actually works best to completely remove it from the page flow all along, so the content below it doesn't jump around when its positioning changes. That's why it is `position: absolute` by default, and why the element after it is given a margin-top equivalent to its height. It's also why various measurements were changed to pixels instead of em, so that its height can be calculated more precisely.

This is frustratingly brittle--if we change styles elsewhere on the page that seem to be unrelated, like the amount of padding, then this will require parallel changes. We might not notice that it requires such changes right away, which could result in styling bugs that only affect certain screen resolutions.

  [1]: https://developer.mozilla.org/en-US/docs/Web/Events/scroll#Example
  [2]: https://developers.google.com/web/updates/2016/06/passive-event-listeners?hl=en