### PR TITLE
Intro: check if browser is offline at page load

### DIFF
--- a/packages/thicket-intro/src/App/GifCreator/index.js
+++ b/packages/thicket-intro/src/App/GifCreator/index.js
@@ -12,7 +12,7 @@ export default class GifCreator extends React.Component {
   state = (() => {
     const gifCreated = window.localStorage.getItem('gifCreated')
     return {
-      online: true,
+      online: window.navigator.onLine,
       creating: false,
       gif: window.localStorage.getItem('gif'),
       gifCreated: gifCreated && new Date(Number(gifCreated)),


### PR DESCRIPTION
We were previously assuming that the user has a connection when they first visit the page. This turns out to not be true for at least one kind of user: the person building this app.