### PR TITLE
Camera: fix overflow

### DIFF
--- a/packages/thicket-camera/src/Camera/index.js
+++ b/packages/thicket-camera/src/Camera/index.js
@@ -21,6 +21,7 @@ const Vid = styled.div`
   width: 100%;
   height: 100%;
   overflow: hidden;
+  line-height: 0;
 `
 const videoStyles = {
   width: '100%',


### PR DESCRIPTION
There was a small styling issue that became obvious with dark backgrounds. 

![camera styling issue](https://user-images.githubusercontent.com/221614/32857223-1b52f8bc-ca15-11e7-874a-4e246bdd6dde.png)
