### PR TITLE
Intro: improve gif-to-earth progress bar

### DIFF
--- a/packages/thicket-intro/src/App/App.css
+++ b/packages/thicket-intro/src/App/App.css
@@ -27,3 +27,5 @@ a.muted:focus .highlight, a.muted:hover .highlight { color: #00A9E0 }
 a.muted:active .highlight { color: #06AC4B }
 
 img { max-width: 100% }
+
+small { font-size: 0.7em }

--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
@@ -62,9 +62,6 @@
   background-color: rgba(255,255,255,0.1);
   border-radius: 2px;
 }
-.GifToEarthProgress--progressBars .progress.fromEarth {
-  margin-bottom: 3px;
-}
 .GifToEarthProgress--progressBars .progress div {
   border-radius: 2px;
   animation: loadingBar var(--timeToComplete) linear forwards;
@@ -72,30 +69,14 @@
 .GifToEarthProgress--progressBars .progress.fromMars div {
   background-color: #e75252;
 }
-.GifToEarthProgress--progressBars .progress.fromEarth div {
-  background-color: #00A9E0;
-  float: right;
-}
 
 .GifToEarthProgress .gif {
   line-height: 0;
   position: absolute;
-  width: 44px;
-}
-.GifToEarthProgress .gif.martian {
   background-color: #e75252;
   margin-left: -22px;
   top: calc(100% + 11px);
   animation: gifFromMars var(--timeToComplete) linear forwards;
-}
-.GifToEarthProgress .gif.terran {
-  background-color: #00A9E0;
-  bottom: calc(100% + 11px);
-  height: 34px;
-  font-size: 20px;
-  line-height: 34px;
-  margin-right: -22px;
-  animation: gifFromEarth var(--timeToComplete) linear forwards;
 }
 .GifToEarthProgress .gif img {
   width: 40px;
@@ -109,14 +90,8 @@
   content: " ";
   font-size: 0;
   line-height: 0;
-}
-.GifToEarthProgress .gif.martian:after {
   bottom: 100%;
   border-bottom: 11px solid #e75252;
-}
-.GifToEarthProgress .gif.terran:after {
-  top: 100%;
-  border-top: 11px solid #00A9E0;
 }
 
 @keyframes loadingBar {
@@ -126,8 +101,4 @@
 @keyframes gifFromMars {
   0% { left: var(--progress) }
   100% { left: 100% }
-}
-@keyframes gifFromEarth {
-  0% { right: var(--progress) }
-  100% { right: 100% }
 }

--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/index.js
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/index.js
@@ -17,12 +17,8 @@ const Sending = ({ gif }) => (
   <div>
     <img src={mars} alt="mars" className="mars" />
     <div className="GifToEarthProgress--progressBars">
-      <div className="gif terran">
-        ?
-      </div>
-      <div className="progress fromEarth"><div /></div>
       <div className="progress fromMars"><div /></div>
-      <div className="gif martian">
+      <div className="gif">
         <img src={gif} alt="your GIF" />
       </div>
     </div>

--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/index.js
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/index.js
@@ -8,12 +8,11 @@ const sendingCopy = scrollTo => [
   <p key="p">
     With traditional apps, your fellow Martians would have to wait until it
     makes a round-trip to an Earth server. With Thicket, we get it right away.
-    Your Earth friends will get it as fast as lightspeed allows.
+    We’re sending your GIF off to your Earth friends now; they’ll get it as
+    fast as lightspeed allows.
   </p>,
   <p key="p2">
-    And <em>maybe</em> an Earth friend just sent you something, too!
-    {' '}<em>Maybe</em> if you stick around for three minutes, you'll find out
-    what it is!
+    <small>Learn more about Thicket while you’re waiting.</small>
   </p>,
   <Arrow key="p3" scrollTo={scrollTo} />,
 ]


### PR DESCRIPTION
Make it look more like the one in #80

I made a judgement call to leave the gif below the bar, instead of putting it on top. This is because I don't know what the style should look like when the image is right next to the planets. The only good way to do that I can think of seems like it will take too long to code.

Also, the designs show the arrow being aligned to the bottom of the page. To accomplish this would require restructuring a big portion of the app, and it doesn't seem worth it to me. So I also made a judgement call to leave this as-is.

![thicket-intro nice gif](https://user-images.githubusercontent.com/221614/32869725-8ec33baa-ca46-11e7-9d29-0bcc7a848bae.png)
