### PR TITLE
Intro: Move styles to CSS

### DIFF
--- a/packages/thicket-intro/src/App/Hero/Hero.css
+++ b/packages/thicket-intro/src/App/Hero/Hero.css
@@ -4,6 +4,11 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
+
+  background-image: url(./mars.svg), url(./earth.svg), url(./stars.svg);
+  background-repeat: no-repeat, no-repeat, no-repeat;
+  background-position: center bottom, 75% 75%, 100% 100%;
+  background-size: 102%, 1em, cover;
 }
 
 @media(min-height: 400px) {

--- a/packages/thicket-intro/src/App/Hero/index.js
+++ b/packages/thicket-intro/src/App/Hero/index.js
@@ -1,18 +1,10 @@
 import React from 'react'
 import Nav from './Nav'
-import stars from './stars.svg'
-import earth from './earth.svg'
-import mars from './mars.svg'
 import Arrow from '../Arrow'
 import './Hero.css'
 
 export default ({ scrollTo }) => (
-  <header className="Hero" style={{
-    backgroundImage: `url(${mars}), url(${earth}), url(${stars})`,
-    backgroundRepeat: 'no-repeat, no-repeat, no-repeat',
-    backgroundPosition: 'center bottom, 75% 75%, 100% 100%',
-    backgroundSize: '102%, 1em, cover',
-  }}>
+  <header className="Hero">
     <div className="Hero--PinToTop">
       <Nav />
     </div>


### PR DESCRIPTION
When I wrote the styles inline, I did not know that create-react-app was set up to correctly import images within the CSS.