### PR TITLE
Intro: add bg stars to GifToEarth progress bar

### DIFF
--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
@@ -29,6 +29,13 @@
 }
 .GifToEarthProgress.sticky {
   position: fixed;
+  background-image:
+    url(../../../Hero/stars.svg),
+    linear-gradient(to bottom, #172B42 0%, #172B42 95%, rgba(22,43,66,0) 100%)
+    ;
+  background-repeat: no-repeat;
+  background-position: 100% 100%;
+  background-size: cover;
 }
 .GifToEarthProgress + * {
   margin-top: 115px; /* 2 x 32px padding + 51px height of earth */


### PR DESCRIPTION
Sam proposed this in #80. In his version, the with-stars version also has a different background color, which sets it apart more from the following page. I'm not sure adding the stars by themselves provides enough contrast.

## Right before it sticks

![right before it sticks](https://user-images.githubusercontent.com/221614/32870586-9fdab0ea-ca4a-11e7-9c42-4a37364617eb.png)

## Right after it sticks

![right after it sticks](https://user-images.githubusercontent.com/221614/32870591-a7e0ba46-ca4a-11e7-8ac7-e55b5d6cb058.png)
