### PR TITLE
Intro: Hide banner after clicking to it

### DIFF
--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/index.js
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/index.js
@@ -26,17 +26,19 @@ const Sending = ({ gif }) => (
   </div>
 )
 
-const Arrived = ({ scrollTo }) => (
+const Arrived = ({ onClick, scrollTo }) => (
   <div className="arrived">
     <img src={mars} alt="mars" className="mars" />
     <span>
-      Success, interplanetary GIFs exchanged!{' '} <a href={scrollTo}>Check it out!</a>
+      Success, interplanetary GIFs exchanged!{' '} <a href={scrollTo} onClick={onClick}>Check it out!</a>
     </span>
     <img src={earth} alt="earth" className="earth"  />
   </div>
 )
 
 export default class GifToEarthProgress extends React.Component {
+
+  state = { showBanner: true }
 
   componentDidMount() {
     var progress = getProgress(this.props.gifCreated);
@@ -74,6 +76,7 @@ export default class GifToEarthProgress extends React.Component {
   }
 
   maybeStick = scrollPosition => {
+    if (!this.wrap) return;
     if (scrollPosition > this.offset) {
       this.wrap.className = "GifToEarthProgress sticky"
     } else {
@@ -82,6 +85,7 @@ export default class GifToEarthProgress extends React.Component {
   }
 
   adjustOffset = () => {
+    if (!this.wrap) return;
     this.offset = this.wrap.parentElement.offsetTop
   }
 
@@ -93,12 +97,19 @@ export default class GifToEarthProgress extends React.Component {
     )
   }
 
+  stopShowingBanner = () => { this.setState({ showBanner: false }) }
+
   render() {
     const { id, gif, arrived } = this.props
 
+    if (!this.state.showBanner) return null
+
     return (
       <div ref={div => this.wrap = div} className="GifToEarthProgress">
-        {arrived ? <Arrived scrollTo={`#${id}`} /> : <Sending gif={gif} />}
+        {arrived
+          ? <Arrived scrollTo={`#${id}`} onClick={this.stopShowingBanner} />
+          : <Sending gif={gif} />
+        }
       </div>
     )
   }


### PR DESCRIPTION
As Sam mocked up in #80, it makes sense to hide the "interplanetary GIFs exchanged" message after it's no longer relevant. While not a perfect solution, a quick way to do this is to add an `onClick` handler to the "Check it out!" link.

This will cause the banner to stick around if the user scrolls to the section, rather than clicking the link. This doesn't seem like a big enough problem for me to exert the effort to fix it.