### PR TITLE
Intro: fix success bannner width

### DIFF
--- a/packages/thicket-intro/src/App/GifCreator/GifCreator.css
+++ b/packages/thicket-intro/src/App/GifCreator/GifCreator.css
@@ -10,5 +10,6 @@
   margin: 0 auto;
   padding: 1em;
   max-width: 30em;
+  width: 100%;
   position: relative;
 }


### PR DESCRIPTION
It was too narrow when the progress banner is absolutely positioned, and this forming to the same width as the container it's within.

## Before

![thicket-intro success message banner too narrow](https://user-images.githubusercontent.com/221614/32916428-0b73ef7a-caea-11e7-9a3b-9ae93b7676a8.png)

## After

![thicket-intro success message banner full width](https://user-images.githubusercontent.com/221614/32916433-10bc0468-caea-11e7-8d4f-8f8c91cbe643.png)
