### PR TITLE
Intro: Fix GIF-hitting-Earth bug

### DIFF
--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/GifToEarthProgress/GifToEarthProgress.css
@@ -88,6 +88,7 @@
 .GifToEarthProgress .gif img {
   width: 40px;
   margin: 2px;
+  max-width: none; /* override global rule */
 }
 .GifToEarthProgress .gif:after {
   position: absolute;


### PR DESCRIPTION
When the GIF would get close to the right edge of its parent container, the `max-width: 100%` rule would cause it to shrink and look very strange.

<img width="774" alt="screen shot 2017-11-16 at 16 47 55" src="https://user-images.githubusercontent.com/221614/32917737-2148a0bc-caee-11e7-8de3-9b30347e0321.png">
