### PR TITLE
[WIP] IPFS local config

### DIFF
--- a/packages/thicket-webapp/src/database/index.js
+++ b/packages/thicket-webapp/src/database/index.js
@@ -20,18 +20,12 @@ const ipfsConfig = {
   },
   config: {
     Addresses: {
-      Swarm: ['/dns4/star-signal.cloud.ipfs.team/wss/p2p-webrtc-star'],
-      API: '',
-      Gateway: '',
+      Swarm: [
+        '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star'
+      ],
     },
     Bootstrap: [
-      '/dns4/ams-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
-      '/dns4/lon-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3',
-      '/dns4/sfo-3.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM',
-      '/dns4/nyc-1.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm',
-      '/dns4/nyc-2.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
-      '/dns4/wss0.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic',
-      '/dns4/wss1.bootstrap.libp2p.io/tcp/443/wss/ipfs/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6',
+      '/ip4/127.0.0.1/tcp/4003/ws/ipfs/QmPFcnw8WYBGchAT7kJv2s8XiCkEAYUnkx5Zcw25RXwbip',
     ],
   },
 }


### PR DESCRIPTION
This changes will give us a better understanding of the layers and their interactions in the `IPFS` network.

With this changes we will be able to have a working setup that does not connect to the IPFS network but simulates a local network able to distribute content in their same fashion.

There are some tasks still needed:
- Setup and execute `js-ipfs` node.
  - Double check if we can assign an `id` to the node and use that for the `IPFS` config files in the browser.
- Setup and execute `signaling server`
- Setup different IPFS configurations fro `dev` and `prod` environments

This setup allows the devs to run a local network. Meaning, we can access `thicket-webapp` from different browsers (or same browser in regular and incognito modes) and the content created between them will be distributed and available to each other.

We will be able to see how `thicket-webapp` behaves to different users. This will also provide a base to a future `test layer`.

By limiting the number of nodes we can also avoid unnecessary connections that can [potentially crash the browser](https://github.com/ipfs/js-ipfs/issues/950).

[Configuration reference](https://github.com/ipfs/js-ipfs/issues/1092)
