### PR TITLE
Intro: Simplify "GIF Arrived" section

### DIFF
--- a/packages/thicket-intro/src/App/Buttons/Buttons.css
+++ b/packages/thicket-intro/src/App/Buttons/Buttons.css
@@ -4,12 +4,14 @@
   border-radius: 0;
   color: white;
   cursor: pointer;
+  display: inline-block;
   font-size: 0.9em;
   font-family: inherit;
   letter-spacing: 0.1em;
   margin: 1rem;
   padding: 0.75em 3em;
   text-transform: uppercase;
+  text-decoration: none;
 }
 
 .Button:enabled:focus, .Button:enabled:hover {

--- a/packages/thicket-intro/src/App/Buttons/index.js
+++ b/packages/thicket-intro/src/App/Buttons/index.js
@@ -1,8 +1,12 @@
 import React from 'react'
 import './Buttons.css'
 
-export const Button = ({ children, onClick }) => (
-  <button className="Button" onClick={onClick}>{children}</button>
+export const Button = ({ component = 'button', children, ...props }) => (
+  React.createElement(
+    component,
+    { className: 'Button', ...props },
+    children
+  )
 )
 
 export const DisabledButton = ({ children, tip }) => (

--- a/packages/thicket-intro/src/App/GifCreator/NiceGif/index.js
+++ b/packages/thicket-intro/src/App/GifCreator/NiceGif/index.js
@@ -2,12 +2,9 @@ import React from 'react'
 import GifToEarthProgress from './GifToEarthProgress'
 import Arrow from '../../Arrow'
 import Image from '../Image'
+import { Button } from '../../Buttons'
 
 import earth from '../../Hero/earth.svg'
-import download from './download.svg'
-import link from './link.svg'
-import facebook from './facebook.svg'
-import twitter from './twitter.svg'
 
 import './NiceGif.css'
 
@@ -27,26 +24,17 @@ const sendingCopy = ({ scrollTo }) => [
 
 const arrivedCopy = ({ gif }) => [
   <Image key="earth" alt="" src={earth} />,
-  <h2 key="h2">Your GIF finally made it to Earth!</h2>,
+  <h2 key="h2">Your GIF finally made it to Earth from Mars!</h2>,
   <p key="p">
-    View your GIF below and share it with your friends!
+    Thanks for trying out this quick Thicket simulation.
   </p>,
   <img key="gif" alt="your GIF" src={gif} />,
-  <p key="p2"><small>Share this GIF! <em>(Turn WiFi back on)</em></small></p>,
-  <div key="share" className="NiceGif--share">
-    <button onClick={() => alert('todo')}>
-      <img alt="download" src={download} />
-    </button>
-    <button onClick={() => alert('todo')}>
-      <img alt="copy link" src={link} />
-    </button>
-    <button onClick={() => alert('todo')}>
-      <img alt="share on facebook" src={facebook} />
-    </button>
-    <button onClick={() => alert('todo')}>
-      <img alt="tweet" src={twitter} />
-    </button>
-  </div>,
+  <p key="p2">
+    <small>To create more GIFs and share them, head over to Thicket.</small>
+    <Button component="a" href="https://thicket.surge.sh" target="_blank">
+      Visit Thicket
+    </Button>
+  </p>,
 ]
 
 const selectCopyFor = arrived => arrived ? arrivedCopy : sendingCopy


### PR DESCRIPTION
Use styles provided by Sam. No Call To Action to download or share the GIF they created, instead the only CTA is to visit Thicket.

This is partly because it was taking monstrous long to try to get even just GIF-downloading to work. Let alone sharing the GIF, which would require importing `js-ipfs` and recreating Thicket here on the intro page.

It's also nice that there's only one CTA, rather than two.

<img width="635" alt="screen shot 2017-11-21 at 10 33 17" src="https://user-images.githubusercontent.com/221614/33081132-83384540-cea7-11e7-9b96-9e8163eb1e2e.png">
