### PR TITLE
Intro: tighten up style on active share buttons

### DIFF
--- a/packages/thicket-intro/src/App/Share/Share.css
+++ b/packages/thicket-intro/src/App/Share/Share.css
@@ -26,7 +26,7 @@
   transform: scale(1.25);
 }
 .Share-button:active img {
-  transform: scale(.9);
+  transform: scale(1.15);
 }
 
 .Share-button-link {


### PR DESCRIPTION
The animation when clicking down on one of these buttons/links was weirdly huge. This makes it more subtle and expectable.

# Before

![thicket-intro share button active - before](https://user-images.githubusercontent.com/221614/33285203-9b6e2eea-d37f-11e7-8ace-5a9f4978b9a2.gif)


# After

![thicket-intro share button active - after](https://user-images.githubusercontent.com/221614/33285201-9b4e5732-d37f-11e7-910c-26f933446861.gif)
