### PR TITLE
First GIF: add switch in route

### DIFF
--- a/packages/thicket-webapp/src/App/Community/index.js
+++ b/packages/thicket-webapp/src/App/Community/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Route, Link } from 'react-router-dom'
+import { Route, Link, Switch } from 'react-router-dom'
 import { Button, Spinner } from 'thicket-elements'
 import Grid from './Grid'
 import FirstGIF from './FirstGIF'
@@ -98,9 +98,11 @@ class Community extends Component {
           ]}
         </div>
       </div>,
-      <Route key="publication" exact path="/c/:c/:id" render={props => <Publication {...props} />} />,
-      <Route key="first_gif" exact path="/c/:c/first-gif" render={() =>
-        <FirstGIF onClose={() => history.replace(`/c/${c}`)} title={title} community={c} />} />,
+      <Switch key="publication-or-first-gif">
+        <Route exact path="/c/:c/first-gif" render={() =>
+          <FirstGIF onClose={() => history.replace(`/c/${c}`)} title={title} community={c} />} />,
+        <Route exact path="/c/:c/:id" render={props => <Publication {...props} />} />,
+      </Switch>,
       mode === CREATE &&
         <div key="create" className="community__create">
           <Create community={c} nickname={nickname} onSave={this.onSave} />


### PR DESCRIPTION
...to avoid requesting non-existing publication.

This was throwing a weird: `invalid 16 character error` all because the `/c/first-gif` route was colliding with `/c/:c` (publication) route, and we were trying to fetch a non-existing `IPFS hash` of `first-gif`.