### PR TITLE
Feature/hooks onboarding workflow component

### DIFF
--- a/packages/thicket-webapp/src/App/Welcome/index.js
+++ b/packages/thicket-webapp/src/App/Welcome/index.js
@@ -18,46 +18,43 @@ const Loading = ({ onContinue, onboarding }) => {
   return null
 }
 
-const SplashPage = props => {
-  user.put({ onboarding: 'SPLASH_PAGE' })
-  return <div className="welcome__arrived">
-    <h2>Welcome to Thicket, a simple web app for creating and sharing GIFs!</h2>
-    <Button className="welcome__start" onClick={props.onContinue}>Create a GIF!</Button>
-  </div>
-}
+const SplashPage = props => <div className="welcome__arrived">
+  <h2>Welcome to Thicket, a simple web app for creating and sharing GIFs!</h2>
+  <Button className="welcome__start" onClick={props.onContinue}>Create a GIF!</Button>
+</div>
 
-const Explain = props => {
-  user.put({ onboarding: 'QUICK_EXPLANATION' })
-  return <QuickExplanation onComplete={props.onContinue} />
-}
-
-const Access = props => {
-  user.put({ onboarding: 'NEED_CAMERA_ACCESS' })
-  return <CameraAccess onGranted={props.onContinue} />
-}
-
-const CreateFirstGif = props => {
-  user.put({ onboarding: 'CREATING_FIRST_GIF'})
-  return <div className="welcome__create">
-    <CreateGif nickname={props.nickname} onSave={async data => {
-      user.put({ onboarding: 'COMPLETED', nickname: data.nickname })
+const CreateFirstGif = ({ nickname, history }) => <div className="welcome__create">
+  <CreateGif
+    nickname={nickname}
+    onSave={async data => {
+      // no need to call onContinue here since this is setting the onboarding step to completed
+      user.put({ onboarding: COMPLETED, nickname: data.nickname })
       const community = await communities.post(NEW_COMMUNITY_ID)
       community.put({ title: NEW_COMMUNITY, createdBy: data.nickname })
       community.publications.post(data)
-      props.history.push(`/c/${NEW_COMMUNITY_ID}/first-gif`)
-    }} />
-  </div>
+      history.push(`/c/${NEW_COMMUNITY_ID}/first-gif`)
+    }}
+  />
+</div>
+
+const Completed = ({ history }) => {
+  history.replace('/communities')
+  return null
 }
 
 const defaultOnboardingWorkflow = [
   { step: 'LOADING', Component: Loading },
   { step: 'SPLASH_PAGE', Component: SplashPage },
-  { step: 'QUICK_EXPLANATION', Component: Explain },
-  { step: 'NEED_CAMERA_ACCESS', Component: Access },
+  { step: 'QUICK_EXPLANATION', Component: props => <QuickExplanation onComplete={props.onContinue} />},
+  { step: 'NEED_CAMERA_ACCESS', Component: props => <CameraAccess onGranted={props.onContinue} />},
   { step: 'CREATING_FIRST_GIF', Component: CreateFirstGif },
-  { step: COMPLETED, Component: () => null }
+  { step: COMPLETED, Component: Completed }
 ]
 
 export default ({ onboardingWorkflow = x => x, ...props }) => <div className="welcome">
-  <Workflow {...props} workflow={onboardingWorkflow(defaultOnboardingWorkflow)} />
+  <Workflow
+    {...props}
+    workflow={onboardingWorkflow(defaultOnboardingWorkflow)}
+    onContinue={step => user.put({ onboarding: step })}
+  />
 </div>

--- a/packages/thicket-webapp/src/App/index.js
+++ b/packages/thicket-webapp/src/App/index.js
@@ -32,15 +32,6 @@ class App extends Component {
     user.off('update', this.fetchUser)
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    // store.user sends an update event whenever there is an operation that changes data (eg user.put)
-    // even if the underlying data did not change and that was triggering a setState which meant a render
-    // this check avoids unnecessary rerenders
-    return this.state.nickname !== nextState.nickname ||
-      this.state.onboarding !== nextState.onboarding ||
-      this.state.loading !== nextState.loading
-  }
-
   render() {
     const { nickname, loading, onboarding } = this.state
 

--- a/packages/thicket-webapp/src/components/Workflow/index.js
+++ b/packages/thicket-webapp/src/components/Workflow/index.js
@@ -8,15 +8,19 @@ class Workflow extends Component {
   }
 
   render() {
+    // avoid passing raw onContinue to component
+    const { onContinue, ...props } = this.props
     const { Component } = this.props.workflow.find(x => x.step === this.state.step)
-    return <Component onContinue={this.onContinue} {...this.props} />
+    return <Component onContinue={this.onContinue} {...props} />
   }
 
   onContinue = ({ step } = {}) => {
     const { workflow } = this.props
     const currentIndex = workflow.findIndex(x => x.step === this.state.step)
     const nextIndex = workflow.length > currentIndex + 1 ? currentIndex + 1 : currentIndex
-    this.setState({ step: step || workflow[nextIndex].step })
+    const nextStep = step || workflow[nextIndex].step
+    this.setState({ step: nextStep })
+    this.props.onContinue && this.props.onContinue(nextStep)
   }
 
 }


### PR DESCRIPTION
Follow up to #152 & #155 

With this changes the `Welcome` component now uses the `Workflow` component and will update it's step via params (the `onboarding step` value is sent as an attribute from `App` - one way data flow).

There are changes on how to use override the `Onboarding` flow in `thicket-tm`:

```
const TermsOfService = props => {
  return <div>Tos<button onClick={props.onContinue}>Continue</button></div>
}

ReactDOM.render(<App onboardingWorkflow={ossWorkflow => {
  const workflow = ossWorkflow.concat()
  workflow.splice(2, 0, { step: 'TERMS_OF_SERVICE', Component: TermsOfService })
  return workflow
}} />, document.getElementById('root'));
```
