### PR TITLE
Button styles

### DIFF
--- a/packages/thicket-elements/src/Button/index.js
+++ b/packages/thicket-elements/src/Button/index.js
@@ -1,17 +1,24 @@
 import React from 'react'
 import styled from 'styled-components'
 
-const Styled = styled.button`
-  background: #FFF;
-  border: 1px solid #000;
-  color: #000;
-  cursor: pointer;
-  padding: 20px;
-  width: 50%;
+const defaultBoxShadow = '0px 2px 2px rgba(113, 114, 215, 0.34), 0px 0px 2px rgba(113, 114, 215, 0.22)'
 
-  &:hover{
-    background: #000;
-    color: #FFF;
+const Styled = styled.button`
+  background: linear-gradient(23deg, #F7618B, #2A7AFF 140%);
+  box-shadow: ${defaultBoxShadow};
+  border-radius: 4px;
+  color: white;
+  cursor: pointer;
+  font-size: inherit;
+  padding: 1em 3em;
+
+  &:focus, &:hover {
+    box-shadow: ${defaultBoxShadow}, inset 0 0 0 99em rgba(0,0,0,0.1);
+  }
+
+  &:active {
+    box-shadow: 0px 0px 8px rgba(113, 114, 215, 0.32),
+      inset 0 0 0 99em rgba(255, 255, 255, 0.05);
   }
 `
 


### PR DESCRIPTION
I changed the `active` button styles from the designs slightly, because they felt too jarring.

I think it would feel more natural to me if the `hover` and `active` styles were somewhat swapped--the button becomes lighter on hover, and darker when "pressed in" on active.

![thicket-elements button](https://user-images.githubusercontent.com/221614/33517761-f34ec990-d757-11e7-9efb-294a8c470417.gif)
