### PR TITLE
Remove button border

### DIFF
--- a/packages/thicket-elements/src/Button/index.js
+++ b/packages/thicket-elements/src/Button/index.js
@@ -9,6 +9,7 @@ import {
 const Styled = styled.button`
   background: ${linearGradient};
   box-shadow: ${defaultBoxShadow};
+  border: none;
   border-radius: 4px;
   color: white;
   cursor: pointer;


### PR DESCRIPTION
This is a default style that I didn't notice before, because it's subtle when viewed on a light background.

# Before

<img width="286" alt="screen shot 2017-12-04 at 14 47 58" src="https://user-images.githubusercontent.com/221614/33572864-38b524c4-d902-11e7-9691-accc0d53b16b.png">

# After

<img width="293" alt="screen shot 2017-12-04 at 14 48 08" src="https://user-images.githubusercontent.com/221614/33572865-38cc0518-d902-11e7-8683-46667f176491.png">
