### PR TITLE
Use Open Sans font

### DIFF
--- a/packages/thicket-elements/src/Button/index.js
+++ b/packages/thicket-elements/src/Button/index.js
@@ -12,6 +12,7 @@ const Styled = styled.button`
   border-radius: 4px;
   color: white;
   cursor: pointer;
+  font-family: inherit;
   font-size: inherit;
   padding: 1em 3em;
 

--- a/packages/thicket-elements/src/Input/index.js
+++ b/packages/thicket-elements/src/Input/index.js
@@ -11,6 +11,7 @@ const StyledInput = styled.input`
   outline: none;
   border-radius: 4px;
   color: #274058;
+  font-family: inherit;
   font-size: inherit;
   padding: 1em;
   margin: 1px;

--- a/packages/thicket-webapp/src/index.css
+++ b/packages/thicket-webapp/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Open+Sans');
+
 html, body, #root {
   height: 100%;
 }
@@ -6,7 +8,7 @@ html {
   background-color: #102131;
   box-sizing: border-box;
   color: white;
-  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  font-family: 'Open Sans',-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
   font-weight: 300;
   font-size: calc(.85em + 1vw);
   line-height: 1.5;


### PR DESCRIPTION
Part of Sam's designs in #149

We needed the `font-family: inherit` declarations for inputs and buttons in order for this site font to be picked up.