### PR TITLE
Decrease top-bottom input padding

### DIFF
--- a/packages/thicket-elements/src/Input/index.js
+++ b/packages/thicket-elements/src/Input/index.js
@@ -12,7 +12,7 @@ const StyledInput = styled.input`
   border-radius: 4px;
   color: #274058;
   font-size: inherit;
-  padding: 1em;
+  padding: 0.75em 1em;
   margin: 1px;
   caret-color: #D266A0;
 `


### PR DESCRIPTION
This padding looked especially large to me once I switched the font to Open Sans (#175).

# before

<img width="471" alt="before" src="https://user-images.githubusercontent.com/221614/33573707-a2257c40-d904-11e7-93ca-b07c01823de8.png">

# after

<img width="476" alt="after" src="https://user-images.githubusercontent.com/221614/33573706-a218d4ea-d904-11e7-98dc-9a30ec519283.png">