### PR TITLE
Font sizes: make splash page look like the design

### DIFF
--- a/packages/thicket-webapp/src/App/Welcome/Welcome.css
+++ b/packages/thicket-webapp/src/App/Welcome/Welcome.css
@@ -1,14 +1,20 @@
 .welcome{
   height: 100%;
-  widht: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  margin: 0 auto;
+  max-width: 38em;
+  padding: 1.5em;
 }
 
 .welcome__arrived{
   text-align: center;
+}
+
+.welcome__arrived h1{
+  font-weight: normal;
 }
 
 .welcome__create{

--- a/packages/thicket-webapp/src/App/Welcome/index.js
+++ b/packages/thicket-webapp/src/App/Welcome/index.js
@@ -19,7 +19,7 @@ const Loading = ({ onContinue, onboarding }) => {
 }
 
 const SplashPage = props => <div className="welcome__arrived">
-  <h2>Connecting your world to others using the power of GIFs.</h2>
+  <h1>Connecting your world to others using the power of GIFs.</h1>
   <Button className="welcome__start" onClick={props.onContinue}>Create a GIF!</Button>
 </div>
 

--- a/packages/thicket-webapp/src/index.css
+++ b/packages/thicket-webapp/src/index.css
@@ -8,7 +8,7 @@ html {
   color: white;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
   font-weight: 300;
-  font-size: calc(.85em + 1vw);
+  font-size: calc(1em + 0.5vw);
   line-height: 1.5;
 }
 


### PR DESCRIPTION
I tweaked the global font size to make it look a bit more like the designs provided by Sam, specifically focusing on the Splash page as my guide.

<img width="400" alt="screen shot 2017-12-04 at 17 52 27" src="https://user-images.githubusercontent.com/221614/33580706-352e6b8e-d91c-11e7-81bc-195a604b2d02.png">

![thicket splash mobile](https://user-images.githubusercontent.com/221614/33580738-5716140e-d91c-11e7-8deb-12a20bfe30d8.png)

