### PR TITLE
elements demo: add dark toggler

### DIFF
--- a/packages/thicket-elements/demo/src/index.js
+++ b/packages/thicket-elements/demo/src/index.js
@@ -1,14 +1,55 @@
 import React, {Component} from 'react'
 import {render} from 'react-dom'
 
+import styled, { injectGlobal } from 'styled-components'
+
 import Example from '../../src'
 
+const light = 'white'
+const dark = '#102131'
+
+injectGlobal`
+  body { margin: 0 }
+`
+
+const Wrap = styled.main`
+  padding: 1.5em 1.5em 3em;
+  background: ${props => props.dark ? dark  : light };
+  color: ${props => props.dark ? light : dark };
+
+  h1 { margin-top: 0 }
+`
+
+const Head = styled.header`
+  background: ${props => props.dark ? dark : light };
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+
+  & > * { display: inline-block }
+`
+
 class Demo extends Component {
+
+  state = { dark: false }
+
   render() {
-    return <div style={{margin: '0 1.5em 3em'}}>
-      <h1>thicket-elements Demo</h1>
+    return <Wrap dark={this.state.dark}>
+      <Head dark={this.state.dark}>
+        <h1>thicket-elements Demo</h1>
+        <label>
+          <input
+            type="checkbox"
+            checked={this.state.dark}
+            onChange={e => this.setState({ dark: e.target.checked })}
+          />
+          dark
+        </label>
+      </Head>
       <Example/>
-    </div>
+    </Wrap>
   }
 }
 


### PR DESCRIPTION
Make it easier to quickly toggle a dark background, since all of our elements eend to look good with light and dark backgrounds.

<img width="407" alt="dark bg" src="https://user-images.githubusercontent.com/221614/33724434-6a814798-db3d-11e7-978e-e25c37df696d.png">
<img width="413" alt="light bg" src="https://user-images.githubusercontent.com/221614/33724435-6a8b2d80-db3d-11e7-8199-3281739dbfd2.png">
