### PR TITLE
Button: swap active & hover states; remove outline

### DIFF
--- a/packages/thicket-elements/src/Button/index.js
+++ b/packages/thicket-elements/src/Button/index.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import {
   linearGradient,
   defaultBoxShadow,
+  hoverBoxShadow,
   activeBoxShadow,
 } from '../sharedStyles'
 
@@ -15,10 +16,11 @@ const Styled = styled.button`
   cursor: pointer;
   font-family: inherit;
   font-size: inherit;
+  outline: none;
   padding: 1em 3em;
 
   &:focus, &:hover {
-    box-shadow: ${defaultBoxShadow}, inset 0 0 0 99em rgba(0,0,0,0.1);
+    box-shadow: ${hoverBoxShadow};
   }
 
   &:active {

--- a/packages/thicket-elements/src/sharedStyles.js
+++ b/packages/thicket-elements/src/sharedStyles.js
@@ -1,4 +1,5 @@
 export const defaultBoxShadow = '0px 2px 2px rgba(113, 114, 215, 0.34), 0px 0px 2px rgba(113, 114, 215, 0.22)'
-export const activeBoxShadow =  '0px 0px 8px rgba(113,114,215,0.32), inset 0 0 0 99em rgba(255,255,255,0.05)'
+export const hoverBoxShadow = `${defaultBoxShadow}, inset 0 0 0 99em rgba(255,255,255,0.07)`
+export const activeBoxShadow =  '0px 0px 8px rgba(113,114,215,0.32), inset 0 0 0 99em rgba(0,0,0,0.1)'
 export const linearGradient = 'linear-gradient(23deg, #F7618B, #2A7AFF 140%)'
 export const radialGradient = 'radial-gradient(circle at top left,#F7618B, #2A7AFF)'


### PR DESCRIPTION
Minor tweaks to the style of the button. Sam-approved.

See me tabbing to and hovering over it below:

![thicket-elements button](https://user-images.githubusercontent.com/221614/33687771-2e349808-daa7-11e7-8c44-788b66842806.gif)

_(The weird line is an artifact of my screen recorder, not the actual design.)_